### PR TITLE
Wrong spelling of the title in clojure.core/compile.rst: complie

### DIFF
--- a/clojure.core/compile.rst
+++ b/clojure.core/compile.rst
@@ -1,4 +1,4 @@
-complie
+compile
 --------
 
 **(compile lib)**


### PR DESCRIPTION
Wrong spelling of the title in [clojure.core/compile.rst](https://github.com/huangz1990/clojure_api_cn/blob/master/clojure.core/compile.rst): complie, should be **compile**.
